### PR TITLE
Update Playtune to work on Arduino 1.6

### DIFF
--- a/Playtune.cpp
+++ b/Playtune.cpp
@@ -190,9 +190,9 @@
 #define DBUG 0       /* debugging? */
 #define TESLA_COIL 0 /* special Tesla Coil version? */
 
-#include <arduino.h>
+#include <Arduino.h>
 
-#include "playtune.h"
+#include "Playtune.h"
 
 #if defined(__AVR_ATmega8__)
 #define TCCR2A TCCR2

--- a/Playtune.h
+++ b/Playtune.h
@@ -37,7 +37,7 @@
 #ifndef Playtune_h
 #define Playtune_h
 
-#include <arduino.h>
+#include <Arduino.h>
 
 class Playtune
 {


### PR DESCRIPTION
This fixes the compile errors on Arduino 1.6 on Linux.

One problem is still that it seems like the new Arduino does not define **AVR_X** constants, because when running on Arduino Mega 2560, it was only using one channel before I added `#define __AVR_ATmega2560__` to my sketch
